### PR TITLE
Use the latest Faust package releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.7",
-    "@faustwp/cli": "^0.2.10",
+    "@faustwp/cli": "^0.2.12",
     "@faustwp/core": "^0.2.11",
     "graphql": "^16.6.0",
     "next": "^13.1.6",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.7",
-    "@faustwp/cli": "0.2.2",
-    "@faustwp/core": "0.2.3",
+    "@faustwp/cli": "^0.2.10",
+    "@faustwp/core": "^0.2.11",
     "graphql": "^16.6.0",
     "next": "^13.1.6",
     "react": "^18.2.0",


### PR DESCRIPTION
These changes update Faust dependencies to the latest available releases.
This PR also unpins the version in favor of `^` to support updating for minor releases

https://docs.npmjs.com/about-semantic-versioning