### PR TITLE
rebranding from atlas to headless platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Faust Scaffold
 
-This repository contains a starter scaffolding to get you up and running quickly on [WP Engine's Atlas platform](https://wpengine.com/atlas/) with a WordPress site skeleton for more advanced developers.
+This repository contains a starter scaffolding to get you up and running quickly on [WP Engine's Headless Platform](https://wpengine.com/atlas/) with a WordPress site skeleton for more advanced developers.
 
 ## For more information
 
 For more information on this Blueprint please check out the following sources:
 
-- [WP Engine's Atlas Platform](https://wpengine.com/atlas/)
+- [WP Engine's Headless Platform](https://wpengine.com/atlas/)
 - [Faust.js](https://faustjs.org)
 - [WPGraphQL](https://www.wpgraphql.com)
 - [Atlas Content Modeler](https://wordpress.org/plugins/atlas-content-modeler/)
-- [WP Engine's Atlas developer community](https://developers.wpengine.com)
+- [WP Engine's Headless Platform developer community](https://developers.wpengine.com)
 
 ### Contributor License Agreement
 

--- a/wp-templates/front-page.js
+++ b/wp-templates/front-page.js
@@ -58,7 +58,7 @@ export default function Component(props) {
           >
             <h3>Deploy →</h3>
             <p>
-              Deploy your Faust.js app to Atlas along with your WordPress
+              Deploy your Faust.js app to Headless Platform along with your WordPress
               instance.
             </p>
           </Link>


### PR DESCRIPTION
Removing customer-facing references to Atlas and replacing them with Headless Platform